### PR TITLE
do not use vars in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       contents: write
     with:
-      go-version: ${{vars.GO_VERSION}}
-      k6-version: ${{vars.K6_VERSION}}
-      xk6-version: ${{vars.XK6_VERSION}}
-      os: ${{vars.OS}}
-      arch: ${{vars.ARCH}}
+      go-version: 1.24.x
+      k6-version: v1.0.0
+      xk6-version: v1.0.0
+      os: '["linux","windows","darwin"]'
+      arch: '["amd64","arm64"]'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,9 @@ jobs:
       pages: write
       id-token: write
     with:
-      go-version: ${{vars.GO_VERSION}}
-      go-versions: ${{vars.GO_VERSIONS}}
-      golangci-lint-version: ${{vars.GOLANGCI_LINT_VERSION}}
-      platforms: ${{vars.PLATFORMS}}
-      k6-versions: ${{vars.K6_VERSIONS}}
-      xk6-version: ${{vars.XK6_VERSION}}
+      go-version: 1.24.x
+      go-versions: '["1.24.x", "1.23.x"]'
+      golangci-lint-version: v2.1.6
+      platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      k6-versions: '["v1.0.0","v0.58.0"]'
+      xk6-version: 1.0.0


### PR DESCRIPTION
Don't use vars for workflow arguments as they are not available when running the workflow in a contributor's fork.