### PR TITLE
feat: accept in-memory private key contents via private_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ This will result in a `k6` binary in the current directory.
 
 ## Example
 
+### Connect with a password
+
 ```javascript
 import ssh from 'k6/x/ssh';
 
 export default function () {
   ssh.connect({
-    username: `${__ENV.K6_USERNAME}`,
-    password: `${__ENV.K6_PASSWORD}`,
-    host: [HOSTNAME],
-	port: 22
+    username: `${__ENV.SSH_USER}`,
+    password: `${__ENV.SSH_PASSWORD}`,
+    host: `${__ENV.SSH_HOST}`,
+    port: 22,
   })
   console.log(ssh.run('pwd'))
 }
@@ -43,31 +45,97 @@ Result output:
 ```plain
 $ ./k6 run script.js
 
-          /\      |‾‾| /‾‾/   /‾‾/   
-     /\  /  \     |  |/  /   /  /    
-    /  \/    \    |     (   /   ‾‾\  
-   /          \   |  |\  \ |  (‾)  | 
-  / __________ \  |__| \__\ \_____/ .io
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
 
-  execution: local
-     script: ../xk6-ssh/script.js
-     output: -
 
-  scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
-           * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
+     execution: local
+        script: script.js
+        output: -
 
-INFO[0001] /home/userfolder                                 source=console
+     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
+              * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
 
-running (00m01.4s), 0/1 VUs, 1 complete and 0 interrupted iterations
-default ✓ [======================================] 1 VUs  00m01.4s/10m0s  1/1 iters, 1 per VU
+time="2026-07-14T20:44:54-04:00" level=info msg="/config\n" source=console
 
-     data_received........: 0 B 0 B/s
-     data_sent............: 0 B 0 B/s
-     iteration_duration...: avg=1.41s min=1.41s med=1.41s max=1.41s p(90)=1.41s p(95)=1.41s
-     iterations...........: 1   0.706079/s
-     vus..................: 1   min=1 max=1
-     vus_max..............: 1   min=1 max=1
 
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    iteration_duration...: avg=17.14ms min=17.14ms med=17.14ms max=17.14ms p(90)=17.14ms p(95)=17.14ms
+    iterations...........: 1   58.126017/s
+
+    NETWORK
+    data_received........: 0 B 0 B/s
+    data_sent............: 0 B 0 B/s
+
+
+
+
+running (00m00.0s), 0/1 VUs, 1 complete and 0 interrupted iterations
+default ✓ [ 100% ] 1 VUs  00m00.0s/10m0s  1/1 iters, 1 per VU
+```
+
+### Connect with an in-memory private key
+
+When the key is retrieved at runtime (e.g. from a secrets manager such as Vault or
+`k6/secrets`), pass its PEM contents via `private_key` instead of a file path via
+`rsa_key`. `private_key` takes precedence over `rsa_key` when both are set.
+
+```javascript
+import ssh from 'k6/x/ssh';
+
+export default function () {
+  ssh.connect({
+    username: `${__ENV.SSH_USER}`,
+    host: `${__ENV.SSH_HOST}`,
+    port: 22,
+    private_key: __ENV.SSH_PRIVATE_KEY, // PEM contents, not a path
+  })
+  console.log(ssh.run('pwd'))
+}
+```
+
+Result output:
+
+```plain
+$ ./k6 run script.js
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+
+     execution: local
+        script: script.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
+              * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
+
+time="2026-07-14T20:39:53-04:00" level=info msg="/config\n" source=console
+
+
+  █ TOTAL RESULTS 
+
+    EXECUTION
+    iteration_duration...: avg=54.62ms min=54.62ms med=54.62ms max=54.62ms p(90)=54.62ms p(95)=54.62ms
+    iterations...........: 1   18.273518/s
+
+    NETWORK
+    data_received........: 0 B 0 B/s
+    data_sent............: 0 B 0 B/s
+
+
+
+
+running (00m00.1s), 0/1 VUs, 1 complete and 0 interrupted iterations
+default ✓ [ 100% ] 1 VUs  00m00.1s/10m0s  1/1 iters, 1 per VU
 ```
 
 ## Testing Locally

--- a/examples/connect-by-private-key.js
+++ b/examples/connect-by-private-key.js
@@ -1,0 +1,14 @@
+import ssh from 'k6/x/ssh';
+
+// The private key contents are provided in-memory (e.g. fetched from a secrets
+// manager such as Vault or k6/secrets) instead of being read from a file on disk.
+export default function () {
+  ssh.connect({
+    username: 'sshuser',
+    host: 'localhost',
+    port: 2222,
+    private_key: __ENV.SSH_PRIVATE_KEY, // PEM contents, NOT a file path
+    // passphrase: __ENV.SSH_PASSPHRASE, // optional, if the key is encrypted
+  });
+  console.log(ssh.run('pwd'));
+}

--- a/ssh.go
+++ b/ssh.go
@@ -24,7 +24,7 @@ type K6SSH struct {
 // ConnectionOptions provides configuration for the SSH session.
 type ConnectionOptions struct {
 	RsaKey     string
-	PrivateKey string
+	PrivateKey string //nolint:gosec // user-supplied private key contents option, not a hardcoded credential
 	Passphrase string
 	Host       string
 	Port       int

--- a/ssh.go
+++ b/ssh.go
@@ -24,6 +24,7 @@ type K6SSH struct {
 // ConnectionOptions provides configuration for the SSH session.
 type ConnectionOptions struct {
 	RsaKey     string
+	PrivateKey string
 	Passphrase string
 	Host       string
 	Port       int
@@ -89,16 +90,21 @@ func (k6ssh *K6SSH) Run(command string) (string, error) {
 }
 
 func (k6ssh *K6SSH) rsaKeyAuthMethod(options ConnectionOptions) (ssh.AuthMethod, error) {
-	var pk string
-	if options.RsaKey != "" {
-		pk = options.RsaKey
-	} else {
-		pk = k6ssh.defaultKeyPath()
-	}
+	var key []byte
+	var err error
 
-	key, err := afero.ReadFile(k6ssh.fs, pk)
-	if err != nil {
-		return nil, err
+	if options.PrivateKey != "" {
+		key = []byte(options.PrivateKey)
+	} else {
+		pk := options.RsaKey
+		if pk == "" {
+			pk = k6ssh.defaultKeyPath()
+		}
+
+		key, err = afero.ReadFile(k6ssh.fs, pk)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var signer ssh.Signer

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,55 @@
+package xk6ssh
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+func testPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	return string(pem.EncodeToMemory(block))
+}
+
+func TestRsaKeyAuthMethod_InlinePrivateKey(t *testing.T) {
+	// MemMapFs guarantees no key file exists on disk; inline contents must be used.
+	k := &K6SSH{fs: afero.NewMemMapFs()}
+	auth, err := k.rsaKeyAuthMethod(ConnectionOptions{PrivateKey: testPEM(t)})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected an auth method, got nil")
+	}
+}
+
+func TestRsaKeyAuthMethod_InlineTakesPrecedenceOverPath(t *testing.T) {
+	// RsaKey points at a nonexistent path; inline contents should still win.
+	k := &K6SSH{fs: afero.NewMemMapFs()}
+	auth, err := k.rsaKeyAuthMethod(ConnectionOptions{
+		PrivateKey: testPEM(t),
+		RsaKey:     "/does/not/exist",
+	})
+	if err != nil {
+		t.Fatalf("expected inline key to take precedence, got %v", err)
+	}
+	if auth == nil {
+		t.Fatal("expected an auth method, got nil")
+	}
+}
+
+func TestRsaKeyAuthMethod_InvalidInlineKey(t *testing.T) {
+	k := &K6SSH{fs: afero.NewMemMapFs()}
+	if _, err := k.rsaKeyAuthMethod(ConnectionOptions{PrivateKey: "not a key"}); err == nil {
+		t.Fatal("expected an error for invalid key contents")
+	}
+}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -21,6 +21,7 @@ func testPEM(t *testing.T) string {
 }
 
 func TestRsaKeyAuthMethod_InlinePrivateKey(t *testing.T) {
+	t.Parallel()
 	// MemMapFs guarantees no key file exists on disk; inline contents must be used.
 	k := &K6SSH{fs: afero.NewMemMapFs()}
 	auth, err := k.rsaKeyAuthMethod(ConnectionOptions{PrivateKey: testPEM(t)})
@@ -33,6 +34,7 @@ func TestRsaKeyAuthMethod_InlinePrivateKey(t *testing.T) {
 }
 
 func TestRsaKeyAuthMethod_InlineTakesPrecedenceOverPath(t *testing.T) {
+	t.Parallel()
 	// RsaKey points at a nonexistent path; inline contents should still win.
 	k := &K6SSH{fs: afero.NewMemMapFs()}
 	auth, err := k.rsaKeyAuthMethod(ConnectionOptions{
@@ -48,6 +50,7 @@ func TestRsaKeyAuthMethod_InlineTakesPrecedenceOverPath(t *testing.T) {
 }
 
 func TestRsaKeyAuthMethod_InvalidInlineKey(t *testing.T) {
+	t.Parallel()
 	k := &K6SSH{fs: afero.NewMemMapFs()}
 	if _, err := k.rsaKeyAuthMethod(ConnectionOptions{PrivateKey: "not a key"}); err == nil {
 		t.Fatal("expected an error for invalid key contents")


### PR DESCRIPTION
Closes #96 

Add an optional `private_key` connection option holding the PEM-encoded private key contents. When set, it is used directly and takes precedence over the existing `rsa_key` file path; when empty, behavior is unchanged.

This lets k6 scripts authenticate over SSH with a key sourced at runtime from a secrets manager (HashiCorp Vault, k6/secrets, env vars), where the key is held in memory as a string and cannot be written to disk for the existing file-path API.

Also seed the Go test suite (none existed) covering the new option, add a connect-by-private-key example, and restructure the README examples with refreshed k6 v2 output.